### PR TITLE
インデント訂正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,12 +4,11 @@ Rails.application.routes.draw do
   devise_for :users
   resources :cards, only: [:index] do
   end
-　resources :mypages,only:[:index]
+  resources :mypages,only:[:index]　
   resources :confirm, only: [:index] do
   end
   resources :profile, only: [:index] do
   end
-
   resources :item, only: [:new] do
   end
 end


### PR DESCRIPTION
what
rotes.rbでインデントがずれていたため直しました

why
ルート設定を正しくするため