### PR TITLE
インデント修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   devise_for :users
   resources :cards, only: [:index] do
   end
-  resources :mypages,only:[:index]　
+  resources :mypages,only:[:index]
   resources :confirm, only: [:index] do
   end
   resources :profile, only: [:index] do


### PR DESCRIPTION
what
routes.rbのインデント修正
why
ルートを適正に動かすため