### PR TITLE
登録画面ビュー編集

### DIFF
--- a/app/views/users/registrations/new.html.haml
+++ b/app/views/users/registrations/new.html.haml
@@ -3,25 +3,6 @@
     .header__left
       .header__left-inner
         = image_tag "mercari_icon.png", size: "80x80"
-    .header__right
-      .header__right-inner
-        .point-red 会員情報
-        .point-red:after
-        .point1 電話番号認証
-        .point1:before
-        .point1:after
-
-        .point2 お届け先住所入力
-        .point2:before
-        .point2:after
-
-        .point3 支払い方法
-        .point3:before
-        .point3:after
-
-        .point 完了
-        .point:before
-        .point:after
 
   .new-member-main
     .new-member-main__inner
@@ -31,7 +12,6 @@
         .form__inner
           .form__inner-group
             = f.label :nickname, "ニックネーム"
-            %span.form-require 必須
             = f.text_field :nickname, class: "input-default", placeholder: "例) メルカリ太郎", type: "text"
           .form__inner-group
             = f.label :email, "メールアドレス"
@@ -53,125 +33,26 @@
           .form__inner-group2
             .group2-top
               %label お名前(全角)
-              %span.form-require 必須
           .group2-input-box
             = f.text_field :last_name, class: "input-default-half", placeholder: "例) 山田", type: "text"
             = f.text_field :first_name, class: "input-default-half", placeholder: "例) 彩", type: "text"
           .form__inner-group2
             .group2-top
               = f.label "お名前カナ(全角)", id: "last_name"
-              %span.form-require 必須
           .group2-input-box
             = f.text_field :last_name_furigana, class: "input-default-half", placeholder: "例) ヤマダ", type: "text"
             = f.text_field :first_name_furigana, class: "input-default-half", placeholder: "例) アヤ", type: "text"
-
-          .form__inner-group3
-            = f.label :birthday, "生年月日"
-            %span.form-require 必須
-            .birthday-select-wrap
-              .select-wrap
-                .select-default
-                  %select.select-default{name: "birthday_year"}
-                    %option{value: ""} --
-                    %option{value: "1990"} 1990
-                    %option{value: "1991"} 1991
-                    %option{value: "1992"} 1992
-                    %option{value: "1993"} 1993
-                    %option{value: "1994"} 1994
-                    %option{value: "1995"} 1995
-                    %option{value: "1996"} 1996
-                    %option{value: "1997"} 1997
-                    %option{value: "1998"} 1998
-                    %option{value: "1999"} 1999
-                    %option{value: "2000"} 2000
-                    %option{value: "2001"} 2001
-                    %option{value: "2002"} 2002
-                    %option{value: "2003"} 2003
-                    %option{value: "2004"} 2004
-                    %option{value: "2005"} 2005
-                    %option{value: "2006"} 2006
-                    %option{value: "2007"} 2007
-                    %option{value: "2008"} 2008
-                    %option{value: "2009"} 2009
-                    %option{value: "2010"} 2010
-                    %option{value: "2011"} 2011
-                    %option{value: "2012"} 2012
-                    %option{value: "2013"} 2013
-                    %option{value: "2014"} 2014
-                    %option{value: "2015"} 2015
-                    %option{value: "2016"} 2016
-                    %option{value: "2017"} 2017
-                    %option{value: "2018"} 2018
-                    %option{value: "2019"} 2019
-              .birth-day 年
-              .select-wrap
-                .select-default
-                  %select.select-default{name: "birthday_month"}
-                    %option{value: ""} --
-                    %option{value: "1"} 1
-                    %option{value: "2"} 2
-                    %option{value: "3"} 3
-                    %option{value: "4"} 4
-                    %option{value: "5"} 5
-                    %option{value: "6"} 6
-                    %option{value: "7"} 7
-                    %option{value: "8"} 8
-                    %option{value: "9"} 9
-                    %option{value: "10"} 10
-                    %option{value: "11"} 11
-                    %option{value: "12"} 12
-
-              .birth-day 月
-              .select-wrap
-                .select-default
-                  %select.select-default{name: "birthday_day"}
-                    %option{value: ""} --
-                    %option{value: "1"} 1
-                    %option{value: "2"} 2
-                    %option{value: "3"} 3
-                    %option{value: "4"} 4
-                    %option{value: "5"} 5
-                    %option{value: "6"} 6
-                    %option{value: "7"} 7
-                    %option{value: "8"} 8
-                    %option{value: "9"} 9
-                    %option{value: "10"} 10
-                    %option{value: "11"} 11
-                    %option{value: "12"} 12
-                    %option{value: "13"} 13
-                    %option{value: "14"} 14
-                    %option{value: "15"} 15
-                    %option{value: "16"} 16
-                    %option{value: "17"} 17
-                    %option{value: "18"} 18
-                    %option{value: "19"} 19
-                    %option{value: "20"} 20
-                    %option{value: "21"} 21
-                    %option{value: "22"} 22
-                    %option{value: "23"} 23
-                    %option{value: "24"} 24
-                    %option{value: "25"} 25
-                    %option{value: "26"} 26
-                    %option{value: "27"} 27
-                    %option{value: "28"} 28
-                    %option{value: "29"} 29
-                    %option{value: "30"} 30
-                    %option{value: "31"} 31
-              .birth-day 日
-            %input{name: "birthday", type: "hidden", value: ""}/
           .form-info ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
         .machine__check
           %input{name: "after_save_callback", type: "hidden", value: ""}/
           .machine__check--info
             .machine__check--info-text
-              %p.machine__check--info-text 「登録する」のボタンを押すことにより、
-              = link_to '利用規約', 'リンク'
-              に同意したものとみなします
+              %p.machine__check--info-text 「登録する」のボタンを押すことにより、利用規約に同意したものとみなします。
             = f.submit "登録する", class: "btn-red-next"
             .text__right
               .text__right--inner
                 .text__right--inner-target
-                  = link_to '本人情報の登録について', 'リンク'
+                  = link_to '本人情報の登録について'
 
     .sign-up-footer
       .sign-up-nav


### PR DESCRIPTION
## What
ユーザー登録画面の必須項目をメールアドレスとパスワードのみに変更
生年月日の入力欄を削除

## Why
仕様に近づけるため