### PR TITLE
Userモデル修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,19 @@
 class User < ApplicationRecord
   has_many :items
-  has_many :comments
+  validates :nickname, presence: true, length: { minimum: 1, maximum: 20 }
+  validates :last_name, :first_name, presence: true, length: { minimum: 1, maximum: 10 },
+            format: { with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/, message: "全角のみで入力して下さい" }
+
+  validates :last_name_furigana, :first_name_furigana, presence: true, length: { minimum: 1, maximum: 10 },
+            format: { with: /\A[ァ-ヶー－]+\z/, message: "全角カタカナのみで入力して下さい" }
+
+  validates :password, :password_confirmation, presence: true, length: { minimum: 6},
+            format: { with: /\A[a-zA-Z0-9]+\z/, message: "半角英数字で入力して下さい" }
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
+  validates :email, presence: true, length: { maximum: 255 },
+            format: { with: VALID_EMAIL_REGEX }
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :omniauthable, omniauth_providers: [:facebook, :google_oauth2]
   def self.from_omniauth(auth)

--- a/db/migrate/20190718043328_devise_create_users.rb
+++ b/db/migrate/20190718043328_devise_create_users.rb
@@ -6,16 +6,11 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       ## Database authenticatable
       t.string :email,                       null: false, unique:true, default: ""
       t.string :encrypted_password,          null: false, default: ""
-      t.string :first_name,                  null: true
-      t.string :first_name_furigana,         null: true
-      t.string :last_name,                   null: true
-      t.string :last_name_furigana,          null: true
-      t.string :nickname,                    null: true
-      t.string :phone_number,                null: true, unique: true
-      t.integer :birthday_year,              null: true
-      t.integer :birthday_month,             null: true
-      t.integer :birthday_day,               null: true
-      t.integer :adress_id,                  null: true
+      t.string :first_name,                  null: false
+      t.string :first_name_furigana,         null: false
+      t.string :last_name,                   null: false
+      t.string :last_name_furigana,          null: false
+      t.string :nickname,                    null: false
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/migrate/20190720083241_rename_titre_column_to_books.rb
+++ b/db/migrate/20190720083241_rename_titre_column_to_books.rb
@@ -1,7 +1,0 @@
-class RenameTitreColumnToBooks < ActiveRecord::Migration[5.2]
-  def change
-    def change
-      rename_column :items, :image, :image
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,16 +52,11 @@ ActiveRecord::Schema.define(version: 2019_07_28_035320) do
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "first_name"
-    t.string "first_name_furigana"
-    t.string "last_name"
-    t.string "last_name_furigana"
-    t.string "nickname"
-    t.string "phone_number"
-    t.integer "birthday_year"
-    t.integer "birthday_month"
-    t.integer "birthday_day"
-    t.integer "adress_id"
+    t.string "first_name", null: false
+    t.string "first_name_furigana", null: false
+    t.string "last_name", null: false
+    t.string "last_name_furigana", null: false
+    t.string "nickname", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
## What
Userテーブルのカラム削除
バリデーション記述
- 名前、苗字　文字数：1~10文字まで　全角文字のみ
- 名前、苗字（ふりがな）　文字数：1~10文字まで　全角カナのみ
- ニックネーム　文字数：1~20文字まで　
- パスワード　文字数：6文字以上　半角英数字のみ
- メールアドレス　文字数：最大255文字　[半角英数字]@[半角英数字]の形式
- 全項目で空白を認めない

## Why
新規ユーザー登録画面での誤入力を防ぐため
