### PR TITLE
マイページ　支払い方法のパス変更

### DIFF
--- a/app/views/mypages/_mypages-side.html.haml
+++ b/app/views/mypages/_mypages-side.html.haml
@@ -60,7 +60,7 @@
       = link_to'発送元・お届け先住所変更',"#",{class:"mypages-side-list-item"}
       %i.fas.fa-caret-right
     %li
-      = link_to'支払い方法', new_card_path,{class:"mypages-side-list-item"}
+      = link_to'支払い方法', cards_path,{class:"mypages-side-list-item"}
       %i.fas.fa-caret-right
     %li
       = link_to'メール/パスワード',"#",{class:"mypages-side-list-item"}


### PR DESCRIPTION
# WHAT
マイページで支払い方法をクリックしたときの
パスを変更

# WHY
本家の仕様に近づけるため。